### PR TITLE
Add a generic JSON data provider

### DIFF
--- a/data/commandline_test.go
+++ b/data/commandline_test.go
@@ -6,25 +6,25 @@ import (
 	"testing"
 )
 
-var testMap = map[string]float64{"bar": 1}
+var cliTestMap = map[string]float64{"bar": 1}
 
-var testArray = []string{"a", "b", "c"}
+var cliTestArray = []string{"a", "b", "c"}
 
-var tests = map[string]Data{
+var cliTests = map[string]Data{
 	"foo=bar hello=world":                  {"foo": "bar", "hello": "world"},
 	" x foo=bar 12345 hello=world abc123 ": {"foo": "bar", "hello": "world"},
 	// TODO: Make these tests work
 	// Printing the data structures indicates they should pass, but they fail
-	//"foo={\"bar\":1} hello=world":          {"foo": testMap, "hello": "world"},
-	//"foo=[\"a\",\"b\",\"c\"]":              {"foo": testArray},
+	//"foo={\"bar\":1} hello=world":          {"foo": cliTestMap, "hello": "world"},
+	//"foo=[\"a\",\"b\",\"c\"]":              {"foo": cliTestArray},
 }
 
 func TestCommandLineParsing(t *testing.T) {
-	for cli, expected := range tests {
+	for cli, expected := range cliTests {
 		actual, err := NewCommandLine(strings.Split(cli, " ")).GetData()
 
 		if err != nil || !reflect.DeepEqual(actual, expected) {
-			t.Errorf("Failed parsing \"%s\" expected %s got %s", cli, expected, actual)
+			t.Errorf("expected %s got %s", expected, actual)
 		}
 	}
 

--- a/data/json.go
+++ b/data/json.go
@@ -1,0 +1,29 @@
+package data
+
+import (
+	gojson "encoding/json"
+	"io"
+	"io/ioutil"
+)
+
+type Json struct {
+	reader io.Reader
+}
+
+func NewJson(r io.Reader) *Json {
+	return &Json{r}
+}
+
+func (p *Json) GetData() (Data, error) {
+	data := make(Data)
+
+	jsonData, err := ioutil.ReadAll(p.reader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = gojson.Unmarshal(jsonData, &data)
+
+	return data, err
+}

--- a/data/json_test.go
+++ b/data/json_test.go
@@ -1,0 +1,20 @@
+package data
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+var jsonTests = map[*bytes.Buffer]Data{
+	bytes.NewBufferString("{\"foo\" : \"bar\"}"): {"foo": "bar"},
+}
+
+func TestJsonParsing(t *testing.T) {
+	for reader, expected := range jsonTests {
+		actual, err := NewJson(reader).GetData()
+		if err != nil || !reflect.DeepEqual(actual, expected) {
+			t.Errorf("`expected %s got %s", expected, actual)
+		}
+	}
+}

--- a/data/jsonfile.go
+++ b/data/jsonfile.go
@@ -1,28 +1,17 @@
 package data
 
-import (
-	"encoding/json"
-	"io/ioutil"
-)
+import "os"
 
 type JsonFile struct {
-	path string
+	*Json
 }
 
-func NewJsonFile(path string) *JsonFile {
-	return &JsonFile{path}
-}
-
-func (p *JsonFile) GetData() (Data, error) {
-	data := make(Data)
-
-	jsonData, err := ioutil.ReadFile(p.path)
+func NewJsonFile(path string) (*JsonFile, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY, 0600)
 
 	if err != nil {
 		return nil, err
 	}
 
-	err = json.Unmarshal(jsonData, &data)
-
-	return data, err
+	return &JsonFile{&Json{file}}, nil
 }

--- a/main.go
+++ b/main.go
@@ -120,9 +120,13 @@ func main() {
 
 	switch {
 	case *jsonPtr != "":
-		prv = data.NewJsonFile(*jsonPtr)
+		prv, err = data.NewJsonFile(*jsonPtr)
 	default:
 		prv = data.NewCommandLine(flag.Args())
+	}
+
+	if err != nil {
+		quit(err)
 	}
 
 	switch {

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ build:
 	go build -ldflags '$(GO_LDFLAGS)' -v -o build/cauldron $(PACKAGE)
 
 test:
-	go test $(shell go list ./... | grep -v /vendor/)
+	go test -v $(shell go list ./... | grep -v /vendor/)
 
 clean:
 	@rm -rf build/


### PR DESCRIPTION
Add a generic JSON parsing data provider that can be reused later.

Moved the JsonFile provider to use it.

Resolves issue #6 